### PR TITLE
Deploy the site to Github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: ["**", "!update/**", "!pr/**"]
+  push:
+    branches: ["**", "!update/**", "!pr/**"]
+    tags: [v*]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  site:
+    name: Generate Site
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        java: [temurin@11]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Java (temurin@11)
+        id: setup-java-temurin-11
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+
+      - name: sbt update
+        if: matrix.java == 'temurin@11' && steps.setup-java-temurin-11.outputs.cache-hit == 'false'
+        run: sbt +update
+
+      - name: Compile code
+        run: sbt fastLinkJS
+
+      - name: Setup npm
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Copy samples
+        run: cp -r resources dist/
+
+      - name: Publish site
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          keep_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ bin/
 
 # general
 *.class
+dist

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ The commands in `.github/workflows/ci.yml` will automatically build and publish 
 
 Note that your main branch must be called `main` (the current default), not `master` (which older repositories might use.) See [renaming a branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch)
 
-Then visit <username>.github.io/sos-sampler to see the deployed site.
+Then visit `username.github.io/sos-sampler` to see the deployed site.

--- a/README.md
+++ b/README.md
@@ -5,3 +5,8 @@ UI to test and showcase the Sounds of Scala's sampler instrument
 
 <img width="1512" alt="Screenshot 2024-08-25 at 17 20 51" src="https://github.com/user-attachments/assets/ddba2eb0-0fa5-455d-a4a8-ffcc0344c770">
 
+To develop:
+
+- `sbt fastLinkJS` to compile the Scala code
+- `npm run preview` to build and serve locally
+- `cp -r resources dist/resources` to move the samples into a location the local server can find

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ To develop:
 - `sbt fastLinkJS` to compile the Scala code
 - `npm run preview` to build and serve locally
 - `cp -r resources dist/resources` to move the samples into a location the local server can find
+
+
+To publish:
+
+The commands in `.github/workflows/ci.yml` will automatically build and publish a site containing the application. To serve this from Github pages:
+
+1. Settings > Pages > Deploy from a branch
+2. Branch is `gh-pages`
+
+Note that your main branch must be called `main` (the current default), not `master` (which older repositories might use.) See [renaming a branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch)
+
+Then visit <username>.github.io/sos-sampler to see the deployed site.

--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ lazy val root = project
     libraryDependencies ++= Seq(
       "com.raquo" %%% "laminar" % "16.0.0",
       "org.scala-js" %%% "scalajs-dom" % "2.8.0",
-      "org.soundsofscala" %%% "sounds-of-scala" % "0.1-cfa7d77-SNAPSHOT",
+      "org.soundsofscala" %%% "sounds-of-scala" % "0.1.0-test1",
       "com.github.japgolly.scalacss" %%% "core" % "1.0.0"
     )
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.0
+sbt.version=1.10.1

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from "vite";
 import scalaJSPlugin from "@scala-js/vite-plugin-scalajs";
 
 export default defineConfig({
+  base: "./", // Use ./ to ensure relative paths
   plugins: [scalaJSPlugin()],
 });


### PR DESCRIPTION
1. Deploy the site to Github pages whenever there is a commit. Controlled by `.github/workflows/ci.yml`
2. Document development and deployment process
3. Assorted fiddling to get things working

Note you'll need to rename the main branch from `master` to `main` for this to work. Follow the link in the README to see how to do this (it's straightforward). 

See https://noelwelsh.github.io/sos-sampler/ for a deployed example. 